### PR TITLE
Fixed broken argument parsing in bnl_creator.pl

### DIFF
--- a/tools/creator/bnl_creator.pl
+++ b/tools/creator/bnl_creator.pl
@@ -52,7 +52,7 @@ while( @ARGV )
 	my $sw = shift @ARGV;
 	if( $sw =~ /^(\-|\-\-|\/)(.+)$/ )
 	{
-		$sw = lc $sw;
+		$sw = lc $2;
 
 		if( $sw eq 'input' )
 		{


### PR DESCRIPTION
Předně díky za skvělou práci, právě jí využívám k podomáckému „překladu“ jedné knížky do jiného jazyka!

Ve skriptu tools/creator/bnl_creator.pl mi nefungovaly argumenty input a output. Kód při kontrole argumentů očekával, že budou prefixovány "-", "--" nebo "/", ale tento prefix před porovnáváním názvu argumentu neodtrhl, takže u tohoto skriptu nešly před opravou tyto argumenty reálně použít.