### PR TITLE
Automatize labeling jump table destinations with case

### DIFF
--- a/tools/firmware_disasm/dissector.py
+++ b/tools/firmware_disasm/dissector.py
@@ -431,8 +431,8 @@ def jumptable_preparse(param1, param2_dict, lineno):
         base = 0
 
     if 'prefix' in param2_dict:
-        prefix = param2_dict['prefix']
-        add_symbol(f"jmptbl_{prefix}_{g_PC:06x}", g_PC)
+        prefix = "auto_" + param2_dict['prefix']
+        add_symbol(f"{prefix}_{g_PC:06x}", g_PC)
         del param2_dict['prefix']
     else:
         prefix = add_auto_symbol( "jmptbl", g_PC )

--- a/tools/firmware_disasm/mapfile.def
+++ b/tools/firmware_disasm/mapfile.def
@@ -2499,24 +2499,24 @@ skip 0x2bf5e
 
 0x40bbe3	Switch_on_30_to_51|a
 
-#0x40bd75	switch_handler_fwcode_30_volplus|a
-#0x40bd83	switch_handler_fwcode_31_volminus|a 
+0x40bd75	switch_handler_fwcode_30_volplus|a
+0x40bd83	switch_handler_fwcode_31_volminus|a 
 #0x40bd91	switch_handler_fwcode_32_unk|a
 #0x40bd97	switch_handler_fwcode_33_unk|a
-#0x40bd9d	switch_handler_fwcode_40_mp3|a
+0x40bd9d	switch_handler_fwcode_40_mp3|a
 #0x40bda5	switch_handler_fwcode_41_unk|a
-#0x40bda9	switch_handler_fwcode_42_mp3_pause|a
-#0x40bdad	switch_handler_fwcode_43_mp3_play|a 
-#0x40bdb1	switch_handler_fwcode_44_mp3_stop|a 
-#0x40bdb5	switch_handler_fwcode_45_mp3_next|a 
-#0x40bdb9	switch_handler_fwcode_46_mp3_prev|a 
+0x40bda9	switch_handler_fwcode_42_mp3_pause|a
+0x40bdad	switch_handler_fwcode_43_mp3_play|a 
+0x40bdb1	switch_handler_fwcode_44_mp3_stop|a 
+0x40bdb5	switch_handler_fwcode_45_mp3_next|a 
+0x40bdb9	switch_handler_fwcode_46_mp3_prev|a 
 #0x40bdbd	switch_handler_fwcode_47_unk|a
 #0x40bdc1	switch_handler_fwcode_48_unk|a
 #0x40bdc5	switch_handler_fwcode_49_unk|a
 #0x40bdc9	switch_handler_fwcode_4a_unk|a
 #0x40bdcd	switch_handler_fwcode_4b_unk|a
 #0x40bdd1	switch_handler_fwcode_4c_unk|a
-#0x40bde8	switch_handler_fwcode_50_compare|a
+0x40bde8	switch_handler_fwcode_50_compare|a
 #0x40bdf0	switch_handler_fwcode_51_unk|a
 
 0x40bc21	Switch_on_00_to_12|a
@@ -2525,7 +2525,7 @@ skip 0x2bf5e
 0x40bd69	handler_fwcode_11_unk|a
 0x40bd71	handler_fwcode_12_unk|a
 
-#0x40be0c	switch_handler_fwcode_80_stop|a
+0x40be0c	switch_handler_fwcode_80_stop|a
 #0x40be14	switch_handler_fwcode_81_unk|a
 #0x40be1c	switch_handler_fwcode_82_unk|a
 #0x40be24	switch_handler_fwcode_83_unk|a
@@ -2753,24 +2753,24 @@ skip 0x2bf5e
 #0x40d715	switch_handler_fwcode_ef_unk|c
 #0x40d815	switch_handler_fwcode_MULTI_unk|c
 
-#0x40d2ce	switch_handler_fwcode_30_volplus|c 
-#0x40d2dc	switch_handler_fwcode_31_volminus|c
+0x40d2ce	switch_handler_fwcode_30_volplus|c 
+0x40d2dc	switch_handler_fwcode_31_volminus|c
 #0x40d2ea	switch_handler_fwcode_32_unk|c
 #0x40d2f0	switch_handler_fwcode_33_unk|c
-#0x40d2f6	switch_handler_fwcode_40_mp3|c
+0x40d2f6	switch_handler_fwcode_40_mp3|c
 #0x40d2fe	switch_handler_fwcode_41_unk|c
-#0x40d37e	switch_handler_fwcode_42_mp3_pause|c
-#0x40d388	switch_handler_fwcode_43_mp3_play|c
-#0x40d408	switch_handler_fwcode_44_mp3_stop|c
-#0x40d40c	switch_handler_fwcode_45_mp3_next|c
-#0x40d478	switch_handler_fwcode_46_mp3_prev|c
+0x40d37e	switch_handler_fwcode_42_mp3_pause|c
+0x40d388	switch_handler_fwcode_43_mp3_play|c
+0x40d408	switch_handler_fwcode_44_mp3_stop|c
+0x40d40c	switch_handler_fwcode_45_mp3_next|c
+0x40d478	switch_handler_fwcode_46_mp3_prev|c
 #0x40d4e4	switch_handler_fwcode_47_unk|c
 #0x40d4e8	switch_handler_fwcode_48_unk|c
 #0x40d4ee	switch_handler_fwcode_49_unk|c
 #0x40d4f3	switch_handler_fwcode_4a_unk|c
 #0x40d4f9	switch_handler_fwcode_4b_unk|c
 #0x40d4ff	switch_handler_fwcode_4c_unk|c
-#0x40d516	switch_handler_fwcode_50_compare|c 
+0x40d516	switch_handler_fwcode_50_compare|c 
 #0x40d51e	switch_handler_fwcode_51_unk|c
 
 0x40d2a5	handler_fwcode_00_unk|c
@@ -2787,7 +2787,7 @@ skip 0x2bf5e
 #0x40d55e	switch_handler_fwcode_76_unk|c
 #0x40d565	switch_handler_fwcode_77_unk|c
 #0x40d56c	switch_handler_fwcode_78_unk|c
-#0x40d573	switch_handler_fwcode_80_stop|c
+0x40d573	switch_handler_fwcode_80_stop|c
 #0x40d57b	switch_handler_fwcode_81_unk|c
 #0x40d583	switch_handler_fwcode_82_unk|c
 #0x40d58b	switch_handler_fwcode_83_unk|c


### PR DESCRIPTION
Přidává ke keyword `jumptable` volitelné parametry `base` a `prefix`. Prošel jsem všechny a `base` nastavil ručně.

```
[02fd7c] 0x417ebe 1d 82                .jumptable auto_jmptbl_dst_41821d ;(0x41821d)
[02fd7e] 0x417ebf 07 85                .jumptable auto_jmptbl_dst_418507 ;(0x418507)
[02fd80] 0x417ec0 07 85                .jumptable auto_jmptbl_dst_418507 ;(0x418507)
[02fd82] 0x417ec1 07 85                .jumptable auto_jmptbl_dst_418507 ;(0x418507)
[02fd84] 0x417ec2 07 85                .jumptable auto_jmptbl_dst_418507 ;(0x418507)
[02fd86] 0x417ec3 07 85                .jumptable auto_jmptbl_dst_418507 ;(0x418507)
[02fd88] 0x417ec4 07 85                .jumptable auto_jmptbl_dst_418507 ;(0x418507)
[02fd8a] 0x417ec5 07 85                .jumptable auto_jmptbl_dst_418507 ;(0x418507)
[02fd8c] 0x417ec6 07 85                .jumptable auto_jmptbl_dst_418507 ;(0x418507)
[02fd8e] 0x417ec7 07 85                .jumptable auto_jmptbl_dst_418507 ;(0x418507)
[02fd90] 0x417ec8 07 85                .jumptable auto_jmptbl_dst_418507 ;(0x418507)
[02fd92] 0x417ec9 27 82                .jumptable auto_jmptbl_dst_418227 ;(0x418227)
[02fd94] 0x417eca 31 82                .jumptable auto_jmptbl_dst_418231 ;(0x418231)
[02fd96] 0x417ecb 6d 82                .jumptable auto_jmptbl_dst_41826d ;(0x41826d)
```
↓↓↓
```
[02fd7c] 0x417ebe 1d 82                .jumptable auto_jmptbl_417ebe_case_f01 ;(0x41821d)
[02fd7e] 0x417ebf 07 85                .jumptable auto_jmptbl_417dc9_default_418507 ;(0x418507)
[02fd80] 0x417ec0 07 85                .jumptable auto_jmptbl_417dc9_default_418507 ;(0x418507)
[02fd82] 0x417ec1 07 85                .jumptable auto_jmptbl_417dc9_default_418507 ;(0x418507)
[02fd84] 0x417ec2 07 85                .jumptable auto_jmptbl_417dc9_default_418507 ;(0x418507)
[02fd86] 0x417ec3 07 85                .jumptable auto_jmptbl_417dc9_default_418507 ;(0x418507)
[02fd88] 0x417ec4 07 85                .jumptable auto_jmptbl_417dc9_default_418507 ;(0x418507)
[02fd8a] 0x417ec5 07 85                .jumptable auto_jmptbl_417dc9_default_418507 ;(0x418507)
[02fd8c] 0x417ec6 07 85                .jumptable auto_jmptbl_417dc9_default_418507 ;(0x418507)
[02fd8e] 0x417ec7 07 85                .jumptable auto_jmptbl_417dc9_default_418507 ;(0x418507)
[02fd90] 0x417ec8 07 85                .jumptable auto_jmptbl_417dc9_default_418507 ;(0x418507)
[02fd92] 0x417ec9 27 82                .jumptable auto_jmptbl_417ebe_case_f0c ;(0x418227)
[02fd94] 0x417eca 31 82                .jumptable auto_jmptbl_417ebe_case_f0d ;(0x418231)
[02fd96] 0x417ecb 6d 82                .jumptable auto_jmptbl_417ebe_case_f0e ;(0x41826d)
[02fd98] 0x417ecc a9 82                .jumptable auto_jmptbl_417ebe_case_f0f ;(0x4182a9)
[02fd9a] 0x417ecd bf 82                .jumptable auto_jmptbl_417ebe_case_f10 ;(0x4182bf)
[02fd9c] 0x417ece e9 82                .jumptable auto_jmptbl_417ebe_case_f11 ;(0x4182e9)
[02fd9e] 0x417ecf 1f 83                .jumptable auto_jmptbl_417ebe_case_f12 ;(0x41831f)
[02fda0] 0x417ed0 57 83                .jumptable auto_jmptbl_417ebe_case_f13 ;(0x418357)
[02fda2] 0x417ed1 8e 83                .jumptable auto_jmptbl_417ebe_case_f14 ;(0x41838e)
[02fda4] 0x417ed2 cc 83                .jumptable auto_jmptbl_417ebe_case_f15 ;(0x4183cc)
[02fda6] 0x417ed3 4e 84                .jumptable auto_jmptbl_417ebe_case_f16 ;(0x41844e)
```

Díky `prefix` taky přestává potřeba pro `switch_handler_fwcode_XX_unk|e` apod., ale stále lze použít pro přejmenování. Případy již označené např. `_mp3_play` jsem nechal.